### PR TITLE
chore(cli): add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and test
+        run: ./gradlew build
+
+  native-image:
+    name: Native Image Smoke Test
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up GraalVM 21
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: 21
+          distribution: graalvm
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build native image
+        run: ./gradlew :springforge-cli:nativeCompile
+
+      - name: Smoke test native binary
+        run: |
+          ./springforge-cli/build/native/nativeCompile/springforge --version
+          ./springforge-cli/build/native/nativeCompile/springforge --no-tui
+          ./springforge-cli/build/native/nativeCompile/springforge --no-tui springforge-cli/src/test/resources/SampleEntity.java

--- a/springforge-cli/build.gradle
+++ b/springforge-cli/build.gradle
@@ -37,7 +37,6 @@ graalvmNative {
             )
             javaLauncher = javaToolchains.launcherFor {
                 languageVersion = JavaLanguageVersion.of(21)
-                vendor = JvmVendorSpec.matching('Oracle')
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow with two jobs:
  - **Build & Test**: JDK 21 (Temurin) + `./gradlew build` on push/PR to main/develop
  - **Native Image Smoke Test**: GraalVM 21 + `nativeCompile` + binary smoke tests
- Remove Oracle vendor lock from GraalVM toolchain config for CI compatibility

## Test plan

- [x] `./gradlew build` passes locally (13 tests)
- [x] CI `build` job passes on GitHub Actions
- [x] CI `native-image` job compiles and smoke-tests the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)