### PR TITLE
feat(engine): implement Core Engine — M1 milestone

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'springforge-tui'
 
 include 'springforge-cli'
+include 'springforge-engine'
+include 'springforge-templates'

--- a/springforge-engine/build.gradle
+++ b/springforge-engine/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    api project(':springforge-templates')
+
+    implementation 'com.github.javaparser:javaparser-core:3.26.4'
+    implementation 'org.yaml:snakeyaml:2.3'
+    implementation 'com.github.spullara.mustache.java:compiler:0.9.14'
+    implementation 'org.slf4j:slf4j-api:2.0.16'
+
+    testImplementation platform('org.junit:junit-bom:5.11.4')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testRuntimeOnly 'org.slf4j:slf4j-simple:2.0.16'
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/ConflictStrategy.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/ConflictStrategy.java
@@ -1,0 +1,6 @@
+package dev.springforge.engine.model;
+
+public enum ConflictStrategy {
+    SKIP,
+    OVERWRITE
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/EntityDescriptor.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/EntityDescriptor.java
@@ -1,0 +1,47 @@
+package dev.springforge.engine.model;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public record EntityDescriptor(
+    String className,
+    String packageName,
+    List<FieldDescriptor> fields,
+    Set<String> classAnnotations,
+    SpringNamespace namespace,
+    boolean hasLombok,
+    String idFieldName,
+    String idFieldType
+) {
+
+    public Optional<FieldDescriptor> idField() {
+        return fields.stream()
+            .filter(FieldDescriptor::isId)
+            .findFirst();
+    }
+
+    public String classNameLower() {
+        if (className.isEmpty()) {
+            return "";
+        }
+        return Character.toLowerCase(className.charAt(0)) + className.substring(1);
+    }
+
+    public String classNamePlural() {
+        String lower = classNameLower();
+        if (lower.endsWith("s") || lower.endsWith("x") || lower.endsWith("z")
+                || lower.endsWith("sh") || lower.endsWith("ch")) {
+            return lower + "es";
+        }
+        if (lower.endsWith("y") && lower.length() > 1
+                && !isVowel(lower.charAt(lower.length() - 2))) {
+            return lower.substring(0, lower.length() - 1) + "ies";
+        }
+        return lower + "s";
+    }
+
+    private static boolean isVowel(char c) {
+        return "aeiou".indexOf(Character.toLowerCase(c)) >= 0;
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/FieldDescriptor.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/FieldDescriptor.java
@@ -1,0 +1,21 @@
+package dev.springforge.engine.model;
+
+public record FieldDescriptor(
+    String name,
+    String type,
+    String genericType,
+    boolean isId,
+    boolean isNullable,
+    boolean isUnique,
+    RelationType relation,
+    String relatedEntityName,
+    boolean isCircularRef
+) {
+
+    public FieldDescriptor withCircularRef(boolean circular) {
+        return new FieldDescriptor(
+            name, type, genericType, isId, isNullable, isUnique,
+            relation, relatedEntityName, circular
+        );
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/FileGenerationResult.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/FileGenerationResult.java
@@ -1,0 +1,7 @@
+package dev.springforge.engine.model;
+
+public record FileGenerationResult(
+    String filePath,
+    GenerationStatus status,
+    String message
+) {}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/GeneratedFile.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/GeneratedFile.java
@@ -1,0 +1,10 @@
+package dev.springforge.engine.model;
+
+import java.nio.file.Path;
+
+public record GeneratedFile(
+    Path outputPath,
+    String content,
+    Layer layer,
+    String entityName
+) {}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/GenerationConfig.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/GenerationConfig.java
@@ -1,0 +1,38 @@
+package dev.springforge.engine.model;
+
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+
+public record GenerationConfig(
+    List<EntityDescriptor> entities,
+    EnumSet<Layer> layers,
+    SpringVersion springVersion,
+    MapperLib mapperLib,
+    ConflictStrategy conflictStrategy,
+    Path outputBasePath,
+    String basePackage,
+    boolean dryRun,
+    boolean verbose
+) {
+
+    public String dtoPackage() {
+        return basePackage + ".dto";
+    }
+
+    public String mapperPackage() {
+        return basePackage + ".mapper";
+    }
+
+    public String repositoryPackage() {
+        return basePackage + ".repository";
+    }
+
+    public String servicePackage() {
+        return basePackage + ".service";
+    }
+
+    public String controllerPackage() {
+        return basePackage + ".controller";
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/GenerationReport.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/GenerationReport.java
@@ -1,0 +1,13 @@
+package dev.springforge.engine.model;
+
+import java.time.Duration;
+import java.util.List;
+
+public record GenerationReport(
+    int totalFiles,
+    int createdFiles,
+    int skippedFiles,
+    int errorFiles,
+    List<FileGenerationResult> results,
+    Duration duration
+) {}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/GenerationStatus.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/GenerationStatus.java
@@ -1,0 +1,7 @@
+package dev.springforge.engine.model;
+
+public enum GenerationStatus {
+    CREATED,
+    SKIPPED,
+    ERROR
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/Layer.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/Layer.java
@@ -1,0 +1,12 @@
+package dev.springforge.engine.model;
+
+public enum Layer {
+    DTO_REQUEST,
+    DTO_RESPONSE,
+    MAPPER,
+    REPOSITORY,
+    SERVICE,
+    SERVICE_IMPL,
+    CONTROLLER,
+    FILE_UPLOAD
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/MapperLib.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/MapperLib.java
@@ -1,0 +1,6 @@
+package dev.springforge.engine.model;
+
+public enum MapperLib {
+    MAPSTRUCT,
+    MODEL_MAPPER
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/RelationType.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/RelationType.java
@@ -1,0 +1,9 @@
+package dev.springforge.engine.model;
+
+public enum RelationType {
+    NONE,
+    ONE_TO_ONE,
+    ONE_TO_MANY,
+    MANY_TO_ONE,
+    MANY_TO_MANY
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/SpringNamespace.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/SpringNamespace.java
@@ -1,0 +1,16 @@
+package dev.springforge.engine.model;
+
+public enum SpringNamespace {
+    JAVAX("javax"),
+    JAKARTA("jakarta");
+
+    private final String packagePrefix;
+
+    SpringNamespace(String packagePrefix) {
+        this.packagePrefix = packagePrefix;
+    }
+
+    public String packagePrefix() {
+        return packagePrefix;
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/model/SpringVersion.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/model/SpringVersion.java
@@ -1,0 +1,16 @@
+package dev.springforge.engine.model;
+
+public enum SpringVersion {
+    V2("javax"),
+    V3("jakarta");
+
+    private final String namespace;
+
+    SpringVersion(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String namespace() {
+        return namespace;
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/parser/JavaAstEntityParser.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/parser/JavaAstEntityParser.java
@@ -1,0 +1,253 @@
+package dev.springforge.engine.parser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+
+import dev.springforge.engine.model.EntityDescriptor;
+import dev.springforge.engine.model.FieldDescriptor;
+import dev.springforge.engine.model.RelationType;
+import dev.springforge.engine.model.SpringNamespace;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parses Java @Entity classes into EntityDescriptor via JavaParser AST.
+ * No runtime reflection or classloading — pure source analysis.
+ */
+public class JavaAstEntityParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JavaAstEntityParser.class);
+
+    private static final Set<String> LOMBOK_ANNOTATIONS = Set.of(
+        "Data", "Getter", "Setter", "Builder", "NoArgsConstructor",
+        "AllArgsConstructor", "RequiredArgsConstructor", "Value"
+    );
+
+    private static final Map<String, RelationType> RELATION_MAP = Map.of(
+        "OneToOne", RelationType.ONE_TO_ONE,
+        "OneToMany", RelationType.ONE_TO_MANY,
+        "ManyToOne", RelationType.MANY_TO_ONE,
+        "ManyToMany", RelationType.MANY_TO_MANY
+    );
+
+    static {
+        StaticJavaParser.getParserConfiguration()
+            .setLanguageLevel(ParserConfiguration.LanguageLevel.RAW);
+    }
+
+    public EntityDescriptor parse(Path javaFile) throws IOException {
+        CompilationUnit cu = StaticJavaParser.parse(javaFile);
+
+        ClassOrInterfaceDeclaration clazz = cu.findFirst(ClassOrInterfaceDeclaration.class)
+            .orElseThrow(() -> new IllegalArgumentException(
+                "No class found in " + javaFile));
+
+        String packageName = cu.getPackageDeclaration()
+            .map(pd -> pd.getNameAsString())
+            .orElse("");
+
+        SpringNamespace namespace = detectNamespace(cu);
+        Set<String> classAnnotations = extractAnnotationNames(clazz);
+        boolean hasLombok = classAnnotations.stream()
+            .anyMatch(LOMBOK_ANNOTATIONS::contains);
+
+        List<FieldDescriptor> fields = new ArrayList<>();
+        String idFieldName = "";
+        String idFieldType = "";
+
+        for (FieldDeclaration field : clazz.getFields()) {
+            if (hasEmbeddedAnnotation(field)) {
+                LOG.warn("@Embedded not supported in v1 — field skipped: {}",
+                    field.getVariables().getFirst()
+                        .map(VariableDeclarator::getNameAsString)
+                        .orElse("unknown"));
+                continue;
+            }
+
+            for (VariableDeclarator var : field.getVariables()) {
+                FieldDescriptor fd = buildFieldDescriptor(field, var);
+                fields.add(fd);
+                if (fd.isId()) {
+                    idFieldName = fd.name();
+                    idFieldType = fd.type();
+                }
+            }
+        }
+
+        return new EntityDescriptor(
+            clazz.getNameAsString(),
+            packageName,
+            fields,
+            classAnnotations,
+            namespace,
+            hasLombok,
+            idFieldName,
+            idFieldType
+        );
+    }
+
+    /**
+     * Detects circular references across a batch of parsed entities.
+     * Returns new list with isCircularRef flags set on back-reference fields.
+     */
+    public List<EntityDescriptor> resolveCircularRefs(List<EntityDescriptor> entities) {
+        Set<String> entityNames = new HashSet<>();
+        for (EntityDescriptor e : entities) {
+            entityNames.add(e.className());
+        }
+
+        Map<String, Set<String>> graph = new HashMap<>();
+        for (EntityDescriptor entity : entities) {
+            Set<String> targets = new HashSet<>();
+            for (FieldDescriptor field : entity.fields()) {
+                if (field.relation() != RelationType.NONE
+                        && field.relatedEntityName() != null
+                        && entityNames.contains(field.relatedEntityName())) {
+                    targets.add(field.relatedEntityName());
+                }
+            }
+            graph.put(entity.className(), targets);
+        }
+
+        Set<String> circularPairs = new HashSet<>();
+        for (Map.Entry<String, Set<String>> entry : graph.entrySet()) {
+            String source = entry.getKey();
+            for (String target : entry.getValue()) {
+                Set<String> targetRefs = graph.getOrDefault(target, Set.of());
+                if (targetRefs.contains(source)) {
+                    circularPairs.add(target + "->" + source);
+                }
+            }
+        }
+
+        if (circularPairs.isEmpty()) {
+            return entities;
+        }
+
+        List<EntityDescriptor> resolved = new ArrayList<>();
+        for (EntityDescriptor entity : entities) {
+            List<FieldDescriptor> updatedFields = new ArrayList<>();
+            for (FieldDescriptor field : entity.fields()) {
+                String key = entity.className() + "->" + field.relatedEntityName();
+                if (circularPairs.contains(key)) {
+                    updatedFields.add(field.withCircularRef(true));
+                } else {
+                    updatedFields.add(field);
+                }
+            }
+            resolved.add(new EntityDescriptor(
+                entity.className(), entity.packageName(), updatedFields,
+                entity.classAnnotations(), entity.namespace(), entity.hasLombok(),
+                entity.idFieldName(), entity.idFieldType()
+            ));
+        }
+        return resolved;
+    }
+
+    private FieldDescriptor buildFieldDescriptor(FieldDeclaration field,
+            VariableDeclarator var) {
+        String name = var.getNameAsString();
+        String type = var.getTypeAsString();
+        String genericType = extractGenericType(var.getType());
+        boolean isId = hasAnnotation(field, "Id");
+        boolean isNullable = !hasAnnotation(field, "Column")
+            || !hasColumnNonNull(field);
+        boolean isUnique = hasColumnUnique(field);
+        RelationType relation = detectRelation(field);
+        String relatedEntityName = (relation != RelationType.NONE)
+            ? (genericType != null ? genericType : type)
+            : null;
+
+        return new FieldDescriptor(
+            name, type, genericType, isId, isNullable,
+            isUnique, relation, relatedEntityName, false
+        );
+    }
+
+    private SpringNamespace detectNamespace(CompilationUnit cu) {
+        for (ImportDeclaration imp : cu.getImports()) {
+            String importName = imp.getNameAsString();
+            if (importName.startsWith("jakarta.persistence")) {
+                return SpringNamespace.JAKARTA;
+            }
+            if (importName.startsWith("javax.persistence")) {
+                return SpringNamespace.JAVAX;
+            }
+        }
+        return SpringNamespace.JAKARTA;
+    }
+
+    private Set<String> extractAnnotationNames(ClassOrInterfaceDeclaration clazz) {
+        Set<String> names = new HashSet<>();
+        for (AnnotationExpr ann : clazz.getAnnotations()) {
+            names.add(ann.getNameAsString());
+        }
+        return names;
+    }
+
+    private boolean hasAnnotation(FieldDeclaration field, String name) {
+        return field.getAnnotations().stream()
+            .anyMatch(a -> a.getNameAsString().equals(name));
+    }
+
+    private boolean hasEmbeddedAnnotation(FieldDeclaration field) {
+        return hasAnnotation(field, "Embedded")
+            || hasAnnotation(field, "EmbeddedId");
+    }
+
+    private boolean hasColumnNonNull(FieldDeclaration field) {
+        return field.getAnnotationByName("Column")
+            .flatMap(a -> a.toNormalAnnotationExpr())
+            .map(a -> a.getPairs().stream()
+                .anyMatch(p -> p.getNameAsString().equals("nullable")
+                    && p.getValue().toString().equals("false")))
+            .orElse(false);
+    }
+
+    private boolean hasColumnUnique(FieldDeclaration field) {
+        return field.getAnnotationByName("Column")
+            .flatMap(a -> a.toNormalAnnotationExpr())
+            .map(a -> a.getPairs().stream()
+                .anyMatch(p -> p.getNameAsString().equals("unique")
+                    && p.getValue().toString().equals("true")))
+            .orElse(false);
+    }
+
+    private RelationType detectRelation(FieldDeclaration field) {
+        for (AnnotationExpr ann : field.getAnnotations()) {
+            RelationType rel = RELATION_MAP.get(ann.getNameAsString());
+            if (rel != null) {
+                return rel;
+            }
+        }
+        return RelationType.NONE;
+    }
+
+    private String extractGenericType(Type type) {
+        if (type instanceof ClassOrInterfaceType classType) {
+            return classType.getTypeArguments()
+                .filter(args -> !args.isEmpty())
+                .map(args -> args.get(0).asString())
+                .orElse(null);
+        }
+        return null;
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/parser/YamlEntityParser.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/parser/YamlEntityParser.java
@@ -1,0 +1,143 @@
+package dev.springforge.engine.parser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import dev.springforge.engine.model.EntityDescriptor;
+import dev.springforge.engine.model.FieldDescriptor;
+import dev.springforge.engine.model.RelationType;
+import dev.springforge.engine.model.SpringNamespace;
+
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Parses YAML entity definitions into EntityDescriptor objects.
+ * Produces the same model as JavaAstEntityParser for interchangeable use.
+ */
+public class YamlEntityParser {
+
+    private static final Map<String, RelationType> RELATION_MAP = Map.of(
+        "OneToOne", RelationType.ONE_TO_ONE,
+        "OneToMany", RelationType.ONE_TO_MANY,
+        "ManyToOne", RelationType.MANY_TO_ONE,
+        "ManyToMany", RelationType.MANY_TO_MANY
+    );
+
+    @SuppressWarnings("unchecked")
+    public List<EntityDescriptor> parse(Path yamlFile) throws IOException {
+        Map<String, Object> root;
+        try (InputStream is = Files.newInputStream(yamlFile)) {
+            Yaml yaml = new Yaml();
+            root = yaml.load(is);
+        }
+
+        if (root == null || !root.containsKey("entities")) {
+            throw new IllegalArgumentException(
+                "Invalid YAML: missing 'entities' key in " + yamlFile);
+        }
+
+        List<Map<String, Object>> entityDefs =
+            (List<Map<String, Object>>) root.get("entities");
+
+        List<EntityDescriptor> result = new ArrayList<>();
+        for (Map<String, Object> entityDef : entityDefs) {
+            result.add(parseEntity(entityDef));
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    private EntityDescriptor parseEntity(Map<String, Object> def) {
+        String name = requireString(def, "name");
+        String pkg = getStringOrDefault(def, "package", "");
+        boolean lombok = getBoolOrDefault(def, "lombok", false);
+
+        Set<String> annotations = new HashSet<>();
+        annotations.add("Entity");
+        if (lombok) {
+            annotations.add("Data");
+        }
+
+        List<Map<String, Object>> fieldDefs =
+            (List<Map<String, Object>>) def.getOrDefault("fields", List.of());
+
+        List<FieldDescriptor> fields = new ArrayList<>();
+        String idFieldName = "";
+        String idFieldType = "";
+
+        for (Map<String, Object> fieldDef : fieldDefs) {
+            FieldDescriptor fd = parseField(fieldDef);
+            fields.add(fd);
+            if (fd.isId()) {
+                idFieldName = fd.name();
+                idFieldType = fd.type();
+            }
+        }
+
+        return new EntityDescriptor(
+            name, pkg, fields, annotations,
+            SpringNamespace.JAKARTA, lombok, idFieldName, idFieldType
+        );
+    }
+
+    private FieldDescriptor parseField(Map<String, Object> def) {
+        String name = requireString(def, "name");
+        String type = requireString(def, "type");
+        boolean isId = getBoolOrDefault(def, "id", false);
+        boolean isNullable = getBoolOrDefault(def, "nullable", true);
+        boolean isUnique = getBoolOrDefault(def, "unique", false);
+
+        String relationStr = getStringOrDefault(def, "relation", null);
+        RelationType relation = RelationType.NONE;
+        String relatedEntityName = null;
+        String genericType = null;
+
+        if (relationStr != null) {
+            relation = RELATION_MAP.getOrDefault(relationStr, RelationType.NONE);
+            if (relation == RelationType.ONE_TO_MANY
+                    || relation == RelationType.MANY_TO_MANY) {
+                genericType = type;
+                relatedEntityName = type;
+                type = "List<" + type + ">";
+            } else {
+                relatedEntityName = type;
+            }
+        }
+
+        return new FieldDescriptor(
+            name, type, genericType, isId, isNullable,
+            isUnique, relation, relatedEntityName, false
+        );
+    }
+
+    private static String requireString(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("Missing required field: " + key);
+        }
+        return value.toString();
+    }
+
+    private static String getStringOrDefault(Map<String, Object> map,
+            String key, String defaultValue) {
+        Object value = map.get(key);
+        return value != null ? value.toString() : defaultValue;
+    }
+
+    private static boolean getBoolOrDefault(Map<String, Object> map,
+            String key, boolean defaultValue) {
+        Object value = map.get(key);
+        if (value instanceof Boolean b) {
+            return b;
+        }
+        return defaultValue;
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/renderer/FileNameResolver.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/renderer/FileNameResolver.java
@@ -1,0 +1,24 @@
+package dev.springforge.engine.renderer;
+
+import dev.springforge.engine.model.Layer;
+
+/**
+ * Resolves the output file name for a given entity + layer combination.
+ */
+public final class FileNameResolver {
+
+    private FileNameResolver() {}
+
+    public static String resolve(String entityClassName, Layer layer) {
+        return switch (layer) {
+            case DTO_REQUEST -> entityClassName + "RequestDto.java";
+            case DTO_RESPONSE -> entityClassName + "ResponseDto.java";
+            case MAPPER -> entityClassName + "Mapper.java";
+            case REPOSITORY -> entityClassName + "Repository.java";
+            case SERVICE -> entityClassName + "Service.java";
+            case SERVICE_IMPL -> entityClassName + "ServiceImpl.java";
+            case CONTROLLER -> entityClassName + "Controller.java";
+            case FILE_UPLOAD -> entityClassName + "FileController.java";
+        };
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/renderer/LayerTemplateMap.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/renderer/LayerTemplateMap.java
@@ -1,0 +1,36 @@
+package dev.springforge.engine.renderer;
+
+import java.util.Map;
+
+import dev.springforge.engine.model.Layer;
+import dev.springforge.engine.model.MapperLib;
+
+/**
+ * Maps each Layer to its Mustache template path.
+ */
+public final class LayerTemplateMap {
+
+    private static final Map<Layer, String> TEMPLATES = Map.of(
+        Layer.DTO_REQUEST, "dto/RequestDto.java.mustache",
+        Layer.DTO_RESPONSE, "dto/ResponseDto.java.mustache",
+        Layer.MAPPER, "mapper/MapstructMapper.java.mustache",
+        Layer.REPOSITORY, "repository/Repository.java.mustache",
+        Layer.SERVICE, "service/Service.java.mustache",
+        Layer.SERVICE_IMPL, "service/ServiceImpl.java.mustache",
+        Layer.CONTROLLER, "controller/Controller.java.mustache",
+        Layer.FILE_UPLOAD, "controller/FileController.java.mustache"
+    );
+
+    private LayerTemplateMap() {}
+
+    public static String get(Layer layer, MapperLib mapperLib) {
+        if (layer == Layer.MAPPER && mapperLib == MapperLib.MODEL_MAPPER) {
+            return "mapper/ModelMapperConfig.java.mustache";
+        }
+        String template = TEMPLATES.get(layer);
+        if (template == null) {
+            throw new IllegalArgumentException("No template for layer: " + layer);
+        }
+        return template;
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/renderer/OutputPathResolver.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/renderer/OutputPathResolver.java
@@ -1,0 +1,37 @@
+package dev.springforge.engine.renderer;
+
+import java.nio.file.Path;
+
+import dev.springforge.engine.model.EntityDescriptor;
+import dev.springforge.engine.model.GenerationConfig;
+import dev.springforge.engine.model.Layer;
+
+/**
+ * Resolves the output file path for a given entity + layer combination.
+ * All paths are relative to the configured outputBasePath.
+ */
+public final class OutputPathResolver {
+
+    private OutputPathResolver() {}
+
+    public static Path resolve(EntityDescriptor entity, Layer layer,
+            GenerationConfig config) {
+        String packagePath = switch (layer) {
+            case DTO_REQUEST, DTO_RESPONSE ->
+                config.dtoPackage().replace('.', '/');
+            case MAPPER ->
+                config.mapperPackage().replace('.', '/');
+            case REPOSITORY ->
+                config.repositoryPackage().replace('.', '/');
+            case SERVICE ->
+                config.servicePackage().replace('.', '/');
+            case SERVICE_IMPL ->
+                config.servicePackage().replace('.', '/') + "/impl";
+            case CONTROLLER, FILE_UPLOAD ->
+                config.controllerPackage().replace('.', '/');
+        };
+
+        String fileName = FileNameResolver.resolve(entity.className(), layer);
+        return config.outputBasePath().resolve(packagePath).resolve(fileName);
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/renderer/TemplateContextBuilder.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/renderer/TemplateContextBuilder.java
@@ -1,0 +1,105 @@
+package dev.springforge.engine.renderer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import dev.springforge.engine.model.EntityDescriptor;
+import dev.springforge.engine.model.FieldDescriptor;
+import dev.springforge.engine.model.GenerationConfig;
+import dev.springforge.engine.model.RelationType;
+
+/**
+ * Builds the template context map from EntityDescriptor + GenerationConfig.
+ * All conditional logic is resolved here — templates remain logic-less.
+ */
+public final class TemplateContextBuilder {
+
+    private TemplateContextBuilder() {}
+
+    public static Map<String, Object> build(EntityDescriptor entity,
+            GenerationConfig config) {
+        Map<String, Object> ctx = new HashMap<>();
+
+        Map<String, Object> entityMap = new HashMap<>();
+        entityMap.put("name", entity.className());
+        entityMap.put("nameLower", entity.classNameLower());
+        entityMap.put("namePlural", entity.classNamePlural());
+        entityMap.put("package", entity.packageName());
+        entityMap.put("hasLombok", entity.hasLombok());
+
+        Map<String, Object> idField = new HashMap<>();
+        idField.put("name", entity.idFieldName());
+        idField.put("type", entity.idFieldType());
+        entityMap.put("idField", idField);
+
+        List<Map<String, Object>> fieldMaps = new ArrayList<>();
+        List<Map<String, Object>> nonIdFields = new ArrayList<>();
+        for (FieldDescriptor field : entity.fields()) {
+            Map<String, Object> fm = buildFieldMap(field);
+            fieldMaps.add(fm);
+            if (!field.isId()) {
+                nonIdFields.add(fm);
+            }
+        }
+        entityMap.put("fields", fieldMaps);
+        entityMap.put("nonIdFields", nonIdFields);
+
+        ctx.put("entity", entityMap);
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("namespace", config.springVersion().namespace());
+        configMap.put("basePackage", config.basePackage());
+        configMap.put("dtoPackage", config.dtoPackage());
+        configMap.put("mapperPackage", config.mapperPackage());
+        configMap.put("servicePackage", config.servicePackage());
+        configMap.put("controllerPackage", config.controllerPackage());
+        configMap.put("repositoryPackage", config.repositoryPackage());
+        configMap.put("apiPath", "/api/v1/" + entity.classNamePlural());
+        configMap.put("springVersion", config.springVersion().name().substring(1));
+        configMap.put("mapperLib", config.mapperLib().name().toLowerCase());
+        configMap.put("useLombok", entity.hasLombok());
+        configMap.put("useMapstruct",
+            config.mapperLib() == dev.springforge.engine.model.MapperLib.MAPSTRUCT);
+        ctx.put("config", configMap);
+
+        return ctx;
+    }
+
+    private static Map<String, Object> buildFieldMap(FieldDescriptor field) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", field.name());
+        map.put("type", field.type());
+        map.put("isId", field.isId());
+        map.put("isNullable", field.isNullable());
+        map.put("isUnique", field.isUnique());
+        map.put("isCircularRef", field.isCircularRef());
+        map.put("hasRelation", field.relation() != RelationType.NONE);
+        map.put("relatedEntityName", field.relatedEntityName());
+
+        String nameCapitalized = field.name().isEmpty() ? ""
+            : Character.toUpperCase(field.name().charAt(0)) + field.name().substring(1);
+        map.put("nameCapitalized", nameCapitalized);
+
+        if (field.isCircularRef() && field.relatedEntityName() != null) {
+            map.put("dtoType", "Long");
+            map.put("dtoFieldName", field.name() + "Id");
+        } else if (field.relation() != RelationType.NONE
+                && field.relatedEntityName() != null) {
+            if (field.relation() == RelationType.ONE_TO_MANY
+                    || field.relation() == RelationType.MANY_TO_MANY) {
+                map.put("dtoType", "List<" + field.relatedEntityName() + "ResponseDto>");
+                map.put("dtoFieldName", field.name());
+            } else {
+                map.put("dtoType", field.relatedEntityName() + "ResponseDto");
+                map.put("dtoFieldName", field.name());
+            }
+        } else {
+            map.put("dtoType", field.type());
+            map.put("dtoFieldName", field.name());
+        }
+
+        return map;
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/renderer/TemplateRenderer.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/renderer/TemplateRenderer.java
@@ -1,0 +1,104 @@
+package dev.springforge.engine.renderer;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+
+import dev.springforge.engine.model.EntityDescriptor;
+import dev.springforge.engine.model.GeneratedFile;
+import dev.springforge.engine.model.GenerationConfig;
+import dev.springforge.engine.model.Layer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Renders Mustache templates into generated Java source files.
+ * Templates are resolved from classpath (built-in) or user overrides.
+ */
+public class TemplateRenderer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TemplateRenderer.class);
+
+    private final MustacheFactory mustacheFactory;
+    private final Path userTemplateDir;
+
+    public TemplateRenderer() {
+        this(null);
+    }
+
+    public TemplateRenderer(Path projectRoot) {
+        this.mustacheFactory = new DefaultMustacheFactory();
+        this.userTemplateDir = projectRoot != null
+            ? projectRoot.resolve(".springforge/templates")
+            : null;
+    }
+
+    public List<GeneratedFile> renderAll(GenerationConfig config) {
+        List<GeneratedFile> results = new ArrayList<>();
+
+        for (EntityDescriptor entity : config.entities()) {
+            for (Layer layer : config.layers()) {
+                GeneratedFile file = renderSingle(entity, layer, config);
+                results.add(file);
+            }
+        }
+
+        return results;
+    }
+
+    public GeneratedFile renderSingle(EntityDescriptor entity, Layer layer,
+            GenerationConfig config) {
+        String templatePath = LayerTemplateMap.get(layer, config.mapperLib());
+        Map<String, Object> context = TemplateContextBuilder.build(entity, config);
+
+        String rendered = render(templatePath, context);
+
+        var outputPath = OutputPathResolver.resolve(entity, layer, config);
+        LOG.debug("Rendered {} for entity {}", templatePath, entity.className());
+
+        return new GeneratedFile(outputPath, rendered, layer, entity.className());
+    }
+
+    String render(String templatePath, Map<String, Object> context) {
+        try (Reader reader = resolveTemplate(templatePath)) {
+            Mustache mustache = mustacheFactory.compile(reader, templatePath);
+            StringWriter writer = new StringWriter();
+            mustache.execute(writer, context);
+            writer.flush();
+            return writer.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(
+                "Failed to render template: " + templatePath, e);
+        }
+    }
+
+    private Reader resolveTemplate(String templatePath) throws IOException {
+        if (userTemplateDir != null) {
+            Path userTemplate = userTemplateDir.resolve(templatePath);
+            if (Files.exists(userTemplate)) {
+                LOG.debug("Using user template override: {}", userTemplate);
+                return new StringReader(
+                    Files.readString(userTemplate, StandardCharsets.UTF_8));
+            }
+        }
+
+        var is = getClass().getResourceAsStream("/templates/" + templatePath);
+        if (is == null) {
+            throw new IOException("Template not found on classpath: " + templatePath);
+        }
+        return new InputStreamReader(is, StandardCharsets.UTF_8);
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/scanner/EntityScanner.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/scanner/EntityScanner.java
@@ -1,0 +1,67 @@
+package dev.springforge.engine.scanner;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Scans a source directory for .java files containing @Entity annotation.
+ * Uses a fast string pre-filter before any AST parsing.
+ */
+public class EntityScanner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EntityScanner.class);
+    private static final String ENTITY_MARKER = "@Entity";
+
+    public List<Path> scanForEntityFiles(Path srcDir) throws IOException {
+        if (!Files.exists(srcDir)) {
+            LOG.warn("Source directory does not exist: {}", srcDir);
+            return Collections.emptyList();
+        }
+        if (!Files.isDirectory(srcDir)) {
+            LOG.warn("Path is not a directory: {}", srcDir);
+            return Collections.emptyList();
+        }
+
+        List<Path> entityFiles = new ArrayList<>();
+
+        Files.walkFileTree(srcDir, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                if (isJavaFile(file) && containsEntityAnnotation(file)) {
+                    entityFiles.add(file);
+                    LOG.debug("Found @Entity file: {}", file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                LOG.warn("Failed to visit file: {}", file, exc);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        LOG.info("Found {} @Entity files in {}", entityFiles.size(), srcDir);
+        return Collections.unmodifiableList(entityFiles);
+    }
+
+    private static boolean isJavaFile(Path file) {
+        return file.toString().endsWith(".java");
+    }
+
+    private static boolean containsEntityAnnotation(Path file) throws IOException {
+        String content = Files.readString(file);
+        return content.contains(ENTITY_MARKER);
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/writer/CodeFileWriter.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/writer/CodeFileWriter.java
@@ -1,0 +1,88 @@
+package dev.springforge.engine.writer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import dev.springforge.engine.model.ConflictStrategy;
+import dev.springforge.engine.model.FileGenerationResult;
+import dev.springforge.engine.model.GeneratedFile;
+import dev.springforge.engine.model.GenerationReport;
+import dev.springforge.engine.model.GenerationStatus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Writes generated files to disk with conflict checking and path validation.
+ * Named CodeFileWriter to avoid conflict with java.io.FileWriter.
+ */
+public class CodeFileWriter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CodeFileWriter.class);
+
+    public GenerationReport writeAll(List<GeneratedFile> files,
+            ConflictStrategy strategy, Path basePath) {
+        Instant start = Instant.now();
+
+        List<FileGenerationResult> results = new ArrayList<>();
+        int created = 0;
+        int skipped = 0;
+        int errors = 0;
+
+        for (GeneratedFile file : files) {
+            FileGenerationResult result = writeSingle(file, strategy, basePath);
+            results.add(result);
+            switch (result.status()) {
+                case CREATED -> created++;
+                case SKIPPED -> skipped++;
+                case ERROR -> errors++;
+            }
+        }
+
+        Duration duration = Duration.between(start, Instant.now());
+        return new GenerationReport(
+            files.size(), created, skipped, errors, results, duration
+        );
+    }
+
+    FileGenerationResult writeSingle(GeneratedFile file,
+            ConflictStrategy strategy, Path basePath) {
+        Path outputPath = file.outputPath();
+        String pathStr = outputPath.toString();
+
+        try {
+            PathValidator.validate(outputPath, basePath);
+        } catch (SecurityException e) {
+            LOG.error("Path traversal rejected: {}", outputPath);
+            return new FileGenerationResult(
+                pathStr, GenerationStatus.ERROR, e.getMessage());
+        }
+
+        if (!ConflictChecker.shouldWrite(outputPath, strategy)) {
+            LOG.info("Skipped: {} (already exists)", pathStr);
+            return new FileGenerationResult(
+                pathStr, GenerationStatus.SKIPPED, "File already exists");
+        }
+
+        try {
+            Files.createDirectories(outputPath.getParent());
+            Files.writeString(outputPath, file.content(), StandardCharsets.UTF_8);
+
+            long size = Files.size(outputPath);
+            LOG.info("Created: {} ({}B)", pathStr, size);
+            return new FileGenerationResult(
+                pathStr, GenerationStatus.CREATED,
+                "Written (" + size + "B)");
+        } catch (IOException e) {
+            LOG.error("Failed to write: {}", pathStr, e);
+            return new FileGenerationResult(
+                pathStr, GenerationStatus.ERROR, e.getMessage());
+        }
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/writer/ConflictChecker.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/writer/ConflictChecker.java
@@ -1,0 +1,21 @@
+package dev.springforge.engine.writer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import dev.springforge.engine.model.ConflictStrategy;
+
+/**
+ * Checks whether a file should be written based on the conflict strategy.
+ */
+public final class ConflictChecker {
+
+    private ConflictChecker() {}
+
+    public static boolean shouldWrite(Path outputPath, ConflictStrategy strategy) {
+        if (!Files.exists(outputPath)) {
+            return true;
+        }
+        return strategy == ConflictStrategy.OVERWRITE;
+    }
+}

--- a/springforge-engine/src/main/java/dev/springforge/engine/writer/PathValidator.java
+++ b/springforge-engine/src/main/java/dev/springforge/engine/writer/PathValidator.java
@@ -1,0 +1,28 @@
+package dev.springforge.engine.writer;
+
+import java.nio.file.Path;
+
+/**
+ * Validates output paths to prevent directory traversal attacks.
+ */
+public final class PathValidator {
+
+    private PathValidator() {}
+
+    /**
+     * Ensures the resolved output path stays within the base directory.
+     * Rejects any path containing "../" traversal.
+     *
+     * @throws SecurityException if path traversal is detected
+     */
+    public static void validate(Path outputPath, Path basePath) {
+        Path normalized = outputPath.normalize();
+        Path normalizedBase = basePath.normalize();
+
+        if (!normalized.startsWith(normalizedBase)) {
+            throw new SecurityException(
+                "Path traversal detected: " + outputPath
+                    + " escapes base directory " + basePath);
+        }
+    }
+}

--- a/springforge-engine/src/test/java/dev/springforge/engine/parser/JavaAstEntityParserTest.java
+++ b/springforge-engine/src/test/java/dev/springforge/engine/parser/JavaAstEntityParserTest.java
@@ -1,0 +1,230 @@
+package dev.springforge.engine.parser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import dev.springforge.engine.model.EntityDescriptor;
+import dev.springforge.engine.model.FieldDescriptor;
+import dev.springforge.engine.model.RelationType;
+import dev.springforge.engine.model.SpringNamespace;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JavaAstEntityParserTest {
+
+    private final JavaAstEntityParser parser = new JavaAstEntityParser();
+
+    private Path testEntity(String name) {
+        return Path.of("src/test/resources/entities/" + name);
+    }
+
+    @Nested
+    @DisplayName("Entity parsing")
+    class EntityParsingTest {
+
+        @Test
+        @DisplayName("should parse @Entity class with all field metadata")
+        void shouldParseEntityClass() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("User.java"));
+
+            assertThat(entity.className()).isEqualTo("User");
+            assertThat(entity.packageName()).isEqualTo("com.example.model");
+            assertThat(entity.classAnnotations()).contains("Entity", "Data", "Builder");
+            assertThat(entity.fields()).hasSize(4);
+        }
+
+        @Test
+        @DisplayName("should detect @Id field name and type")
+        void shouldDetectIdField() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("User.java"));
+
+            assertThat(entity.idFieldName()).isEqualTo("id");
+            assertThat(entity.idFieldType()).isEqualTo("Long");
+        }
+
+        @Test
+        @DisplayName("should detect Lombok presence from class annotations")
+        void shouldDetectLombok() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("User.java"));
+            assertThat(entity.hasLombok()).isTrue();
+
+            EntityDescriptor order = parser.parse(testEntity("Order.java"));
+            assertThat(order.hasLombok()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should extract field names and types")
+        void shouldExtractFieldNamesAndTypes() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("User.java"));
+
+            assertThat(entity.fields())
+                .extracting(FieldDescriptor::name)
+                .containsExactly("id", "username", "email", "orders");
+
+            assertThat(entity.fields())
+                .extracting(FieldDescriptor::type)
+                .containsExactly("Long", "String", "String", "List<Order>");
+        }
+
+        @Test
+        @DisplayName("should detect @Column(nullable=false) as non-nullable")
+        void shouldDetectNonNullable() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("User.java"));
+
+            FieldDescriptor username = entity.fields().stream()
+                .filter(f -> f.name().equals("username"))
+                .findFirst().orElseThrow();
+
+            assertThat(username.isNullable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should detect @Column(unique=true)")
+        void shouldDetectUnique() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("User.java"));
+
+            FieldDescriptor email = entity.fields().stream()
+                .filter(f -> f.name().equals("email"))
+                .findFirst().orElseThrow();
+
+            assertThat(email.isUnique()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Relationship detection")
+    class RelationshipTest {
+
+        @Test
+        @DisplayName("should detect @OneToMany relationship")
+        void shouldDetectOneToMany() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("User.java"));
+
+            FieldDescriptor orders = entity.fields().stream()
+                .filter(f -> f.name().equals("orders"))
+                .findFirst().orElseThrow();
+
+            assertThat(orders.relation()).isEqualTo(RelationType.ONE_TO_MANY);
+            assertThat(orders.genericType()).isEqualTo("Order");
+            assertThat(orders.relatedEntityName()).isEqualTo("Order");
+        }
+
+        @Test
+        @DisplayName("should detect @ManyToOne relationship")
+        void shouldDetectManyToOne() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("Order.java"));
+
+            FieldDescriptor user = entity.fields().stream()
+                .filter(f -> f.name().equals("user"))
+                .findFirst().orElseThrow();
+
+            assertThat(user.relation()).isEqualTo(RelationType.MANY_TO_ONE);
+            assertThat(user.relatedEntityName()).isEqualTo("User");
+        }
+    }
+
+    @Nested
+    @DisplayName("Namespace detection")
+    class NamespaceTest {
+
+        @Test
+        @DisplayName("should detect jakarta namespace")
+        void shouldDetectJakarta() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("User.java"));
+            assertThat(entity.namespace()).isEqualTo(SpringNamespace.JAKARTA);
+        }
+
+        @Test
+        @DisplayName("should detect javax namespace")
+        void shouldDetectJavax() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("Product.java"));
+            assertThat(entity.namespace()).isEqualTo(SpringNamespace.JAVAX);
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases")
+    class EdgeCaseTest {
+
+        @Test
+        @DisplayName("should skip @Embedded fields with warning")
+        void shouldSkipEmbeddedFields() throws IOException {
+            EntityDescriptor entity = parser.parse(testEntity("EmbeddedEntity.java"));
+
+            assertThat(entity.fields())
+                .extracting(FieldDescriptor::name)
+                .doesNotContain("address")
+                .contains("id", "name");
+        }
+
+        @Test
+        @DisplayName("should throw when file has no class declaration")
+        void shouldThrowWhenNoClass() {
+            assertThatThrownBy(() -> parser.parse(testEntity("EmptyFile.java")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No class found");
+        }
+
+        @Test
+        @DisplayName("should throw when file does not exist")
+        void shouldThrowWhenFileNotFound() {
+            assertThatThrownBy(() -> parser.parse(Path.of("nonexistent.java")))
+                .isInstanceOf(Exception.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Circular reference detection")
+    class CircularRefTest {
+
+        @Test
+        @DisplayName("should detect circular references between User and Order")
+        void shouldDetectCircularRefs() throws IOException {
+            EntityDescriptor user = parser.parse(testEntity("User.java"));
+            EntityDescriptor order = parser.parse(testEntity("Order.java"));
+
+            List<EntityDescriptor> resolved =
+                parser.resolveCircularRefs(List.of(user, order));
+
+            EntityDescriptor resolvedUser = resolved.stream()
+                .filter(e -> e.className().equals("User"))
+                .findFirst().orElseThrow();
+
+            EntityDescriptor resolvedOrder = resolved.stream()
+                .filter(e -> e.className().equals("Order"))
+                .findFirst().orElseThrow();
+
+            FieldDescriptor ordersField = resolvedUser.fields().stream()
+                .filter(f -> f.name().equals("orders"))
+                .findFirst().orElseThrow();
+
+            FieldDescriptor userField = resolvedOrder.fields().stream()
+                .filter(f -> f.name().equals("user"))
+                .findFirst().orElseThrow();
+
+            assertThat(ordersField.isCircularRef()).isTrue();
+            assertThat(userField.isCircularRef()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should not flag non-circular relations")
+        void shouldNotFlagNonCircularRefs() throws IOException {
+            EntityDescriptor product = parser.parse(testEntity("Product.java"));
+
+            List<EntityDescriptor> resolved =
+                parser.resolveCircularRefs(List.of(product));
+
+            FieldDescriptor category = resolved.get(0).fields().stream()
+                .filter(f -> f.name().equals("category"))
+                .findFirst().orElseThrow();
+
+            assertThat(category.isCircularRef()).isFalse();
+        }
+    }
+}

--- a/springforge-engine/src/test/java/dev/springforge/engine/parser/YamlEntityParserTest.java
+++ b/springforge-engine/src/test/java/dev/springforge/engine/parser/YamlEntityParserTest.java
@@ -1,0 +1,90 @@
+package dev.springforge.engine.parser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import dev.springforge.engine.model.EntityDescriptor;
+import dev.springforge.engine.model.FieldDescriptor;
+import dev.springforge.engine.model.RelationType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class YamlEntityParserTest {
+
+    private final YamlEntityParser parser = new YamlEntityParser();
+
+    @Test
+    @DisplayName("should parse YAML entity definitions into EntityDescriptor")
+    void shouldParseYamlEntities() throws IOException {
+        List<EntityDescriptor> entities =
+            parser.parse(Path.of("src/test/resources/yaml/entities.yaml"));
+
+        assertThat(entities).hasSize(1);
+
+        EntityDescriptor product = entities.get(0);
+        assertThat(product.className()).isEqualTo("Product");
+        assertThat(product.packageName()).isEqualTo("com.example.model");
+        assertThat(product.hasLombok()).isTrue();
+        assertThat(product.fields()).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("should detect @Id field from YAML")
+    void shouldDetectIdField() throws IOException {
+        List<EntityDescriptor> entities =
+            parser.parse(Path.of("src/test/resources/yaml/entities.yaml"));
+
+        EntityDescriptor product = entities.get(0);
+        assertThat(product.idFieldName()).isEqualTo("id");
+        assertThat(product.idFieldType()).isEqualTo("Long");
+    }
+
+    @Test
+    @DisplayName("should parse relationship types from YAML")
+    void shouldParseRelations() throws IOException {
+        List<EntityDescriptor> entities =
+            parser.parse(Path.of("src/test/resources/yaml/entities.yaml"));
+
+        FieldDescriptor category = entities.get(0).fields().stream()
+            .filter(f -> f.name().equals("category"))
+            .findFirst().orElseThrow();
+
+        assertThat(category.relation()).isEqualTo(RelationType.MANY_TO_ONE);
+        assertThat(category.relatedEntityName()).isEqualTo("Category");
+    }
+
+    @Test
+    @DisplayName("should parse nullable=false from YAML")
+    void shouldParseNullable() throws IOException {
+        List<EntityDescriptor> entities =
+            parser.parse(Path.of("src/test/resources/yaml/entities.yaml"));
+
+        FieldDescriptor name = entities.get(0).fields().stream()
+            .filter(f -> f.name().equals("name"))
+            .findFirst().orElseThrow();
+
+        assertThat(name.isNullable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should throw when YAML is missing 'entities' key")
+    void shouldThrowOnInvalidYaml() {
+        assertThatThrownBy(() ->
+            parser.parse(Path.of("src/test/resources/yaml/invalid.yaml")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("missing 'entities' key");
+    }
+
+    @Test
+    @DisplayName("should throw when YAML file does not exist")
+    void shouldThrowWhenFileNotFound() {
+        assertThatThrownBy(() ->
+            parser.parse(Path.of("nonexistent.yaml")))
+            .isInstanceOf(Exception.class);
+    }
+}

--- a/springforge-engine/src/test/java/dev/springforge/engine/renderer/TemplateRendererTest.java
+++ b/springforge-engine/src/test/java/dev/springforge/engine/renderer/TemplateRendererTest.java
@@ -1,0 +1,303 @@
+package dev.springforge.engine.renderer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import dev.springforge.engine.model.ConflictStrategy;
+import dev.springforge.engine.model.EntityDescriptor;
+import dev.springforge.engine.model.FieldDescriptor;
+import dev.springforge.engine.model.GeneratedFile;
+import dev.springforge.engine.model.GenerationConfig;
+import dev.springforge.engine.model.Layer;
+import dev.springforge.engine.model.MapperLib;
+import dev.springforge.engine.model.RelationType;
+import dev.springforge.engine.model.SpringNamespace;
+import dev.springforge.engine.model.SpringVersion;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TemplateRendererTest {
+
+    private TemplateRenderer renderer;
+    private EntityDescriptor userEntity;
+
+    @BeforeEach
+    void setUp() {
+        renderer = new TemplateRenderer();
+        userEntity = new EntityDescriptor(
+            "User", "com.example.model",
+            List.of(
+                new FieldDescriptor("id", "Long", null, true, false, false,
+                    RelationType.NONE, null, false),
+                new FieldDescriptor("username", "String", null, false, false, false,
+                    RelationType.NONE, null, false),
+                new FieldDescriptor("email", "String", null, false, false, true,
+                    RelationType.NONE, null, false)
+            ),
+            Set.of("Entity", "Data"),
+            SpringNamespace.JAKARTA,
+            true, "id", "Long"
+        );
+    }
+
+    private GenerationConfig config(EnumSet<Layer> layers) {
+        return new GenerationConfig(
+            List.of(userEntity), layers, SpringVersion.V3,
+            MapperLib.MAPSTRUCT, ConflictStrategy.SKIP,
+            Path.of("target/generated"), "com.example",
+            false, false
+        );
+    }
+
+    @Nested
+    @DisplayName("DTO templates")
+    class DtoTemplateTest {
+
+        @Test
+        @DisplayName("should render RequestDto with Lombok annotations")
+        void shouldRenderRequestDto() {
+            GenerationConfig cfg = config(EnumSet.of(Layer.DTO_REQUEST));
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            assertThat(files).hasSize(1);
+            String content = files.get(0).content();
+            assertThat(content).contains("package com.example.dto;");
+            assertThat(content).contains("public class UserRequestDto");
+            assertThat(content).contains("@Data");
+            assertThat(content).contains("private String username;");
+            assertThat(content).contains("private String email;");
+            assertThat(content).doesNotContain("private Long id;");
+        }
+
+        @Test
+        @DisplayName("should render ResponseDto with all fields including id")
+        void shouldRenderResponseDto() {
+            GenerationConfig cfg = config(EnumSet.of(Layer.DTO_RESPONSE));
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains("public class UserResponseDto");
+            assertThat(content).contains("private Long id;");
+            assertThat(content).contains("private String username;");
+        }
+    }
+
+    @Nested
+    @DisplayName("Service templates")
+    class ServiceTemplateTest {
+
+        @Test
+        @DisplayName("should render Service interface with CRUD methods")
+        void shouldRenderServiceInterface() {
+            GenerationConfig cfg = config(EnumSet.of(Layer.SERVICE));
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains("public interface UserService");
+            assertThat(content).contains("Page<UserResponseDto> findAll(Pageable pageable)");
+            assertThat(content).contains("UserResponseDto findById(Long id)");
+            assertThat(content).contains("UserResponseDto create(UserRequestDto dto)");
+            assertThat(content).contains("UserResponseDto update(Long id, UserRequestDto dto)");
+            assertThat(content).contains("void delete(Long id)");
+        }
+
+        @Test
+        @DisplayName("should render ServiceImpl with constructor injection")
+        void shouldRenderServiceImpl() {
+            GenerationConfig cfg = config(EnumSet.of(Layer.SERVICE_IMPL));
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains("public class UserServiceImpl implements UserService");
+            assertThat(content).contains("@Service");
+            assertThat(content).contains("@RequiredArgsConstructor");
+            assertThat(content).contains("private final UserRepository userRepository");
+            assertThat(content).contains("private final UserMapper userMapper");
+        }
+    }
+
+    @Nested
+    @DisplayName("Repository template")
+    class RepositoryTemplateTest {
+
+        @Test
+        @DisplayName("should render Repository extending JpaRepository")
+        void shouldRenderRepository() {
+            GenerationConfig cfg = config(EnumSet.of(Layer.REPOSITORY));
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains(
+                "public interface UserRepository extends JpaRepository<User, Long>");
+            assertThat(content).contains("@Repository");
+        }
+    }
+
+    @Nested
+    @DisplayName("Controller template")
+    class ControllerTemplateTest {
+
+        @Test
+        @DisplayName("should render Controller with CRUD endpoints")
+        void shouldRenderController() {
+            GenerationConfig cfg = config(EnumSet.of(Layer.CONTROLLER));
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains("@RestController");
+            assertThat(content).contains("@RequestMapping(\"/api/v1/users\")");
+            assertThat(content).contains("@GetMapping");
+            assertThat(content).contains("@PostMapping");
+            assertThat(content).contains("@PutMapping(\"/{id}\")");
+            assertThat(content).contains("@DeleteMapping(\"/{id}\")");
+            assertThat(content).contains("jakarta.validation.Valid");
+        }
+
+        @Test
+        @DisplayName("should render FileController with upload endpoint")
+        void shouldRenderFileController() {
+            GenerationConfig cfg = config(EnumSet.of(Layer.FILE_UPLOAD));
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains("UserFileController");
+            assertThat(content).contains("@PostMapping(\"/{id}/upload\")");
+            assertThat(content).contains("MultipartFile");
+        }
+    }
+
+    @Nested
+    @DisplayName("Mapper template")
+    class MapperTemplateTest {
+
+        @Test
+        @DisplayName("should render MapStruct mapper interface")
+        void shouldRenderMapstructMapper() {
+            GenerationConfig cfg = config(EnumSet.of(Layer.MAPPER));
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains("@Mapper(componentModel = \"spring\")");
+            assertThat(content).contains("public interface UserMapper");
+            assertThat(content).contains("UserResponseDto toResponseDto(User entity)");
+        }
+
+        @Test
+        @DisplayName("should render ModelMapper config when configured")
+        void shouldRenderModelMapper() {
+            GenerationConfig cfg = new GenerationConfig(
+                List.of(userEntity), EnumSet.of(Layer.MAPPER), SpringVersion.V3,
+                MapperLib.MODEL_MAPPER, ConflictStrategy.SKIP,
+                Path.of("target/generated"), "com.example",
+                false, false
+            );
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains("@Component");
+            assertThat(content).contains("public class UserMapper");
+            assertThat(content).contains("ModelMapper modelMapper");
+        }
+    }
+
+    @Nested
+    @DisplayName("Spring Boot 2.x support")
+    class SpringBoot2Test {
+
+        @Test
+        @DisplayName("should use javax namespace for Spring Boot 2.x")
+        void shouldUseJavaxNamespace() {
+            GenerationConfig cfg = new GenerationConfig(
+                List.of(userEntity), EnumSet.of(Layer.CONTROLLER), SpringVersion.V2,
+                MapperLib.MAPSTRUCT, ConflictStrategy.SKIP,
+                Path.of("target/generated"), "com.example",
+                false, false
+            );
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).contains("javax.validation.Valid");
+            assertThat(content).doesNotContain("jakarta");
+        }
+    }
+
+    @Nested
+    @DisplayName("No Lombok support")
+    class NoLombokTest {
+
+        @Test
+        @DisplayName("should generate getters/setters when Lombok is absent")
+        void shouldGenerateGettersSetters() {
+            EntityDescriptor noLombokEntity = new EntityDescriptor(
+                "Product", "com.example.model",
+                List.of(
+                    new FieldDescriptor("id", "Long", null, true, false, false,
+                        RelationType.NONE, null, false),
+                    new FieldDescriptor("name", "String", null, false, false, false,
+                        RelationType.NONE, null, false)
+                ),
+                Set.of("Entity"),
+                SpringNamespace.JAKARTA,
+                false, "id", "Long"
+            );
+
+            GenerationConfig cfg = new GenerationConfig(
+                List.of(noLombokEntity), EnumSet.of(Layer.DTO_RESPONSE),
+                SpringVersion.V3, MapperLib.MAPSTRUCT, ConflictStrategy.SKIP,
+                Path.of("target/generated"), "com.example",
+                false, false
+            );
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).doesNotContain("@Data");
+            assertThat(content).contains("getId()");
+            assertThat(content).contains("setId(");
+            assertThat(content).contains("getName()");
+        }
+
+        @Test
+        @DisplayName("should generate constructor in ServiceImpl without Lombok")
+        void shouldGenerateConstructorInServiceImpl() {
+            EntityDescriptor noLombokEntity = new EntityDescriptor(
+                "Product", "com.example.model",
+                List.of(
+                    new FieldDescriptor("id", "Long", null, true, false, false,
+                        RelationType.NONE, null, false)
+                ),
+                Set.of("Entity"),
+                SpringNamespace.JAKARTA,
+                false, "id", "Long"
+            );
+
+            GenerationConfig cfg = new GenerationConfig(
+                List.of(noLombokEntity), EnumSet.of(Layer.SERVICE_IMPL),
+                SpringVersion.V3, MapperLib.MAPSTRUCT, ConflictStrategy.SKIP,
+                Path.of("target/generated"), "com.example",
+                false, false
+            );
+            List<GeneratedFile> files = renderer.renderAll(cfg);
+
+            String content = files.get(0).content();
+            assertThat(content).doesNotContain("@RequiredArgsConstructor");
+            assertThat(content).contains("public ProductServiceImpl(");
+        }
+    }
+
+    @Test
+    @DisplayName("should render all layers for a single entity")
+    void shouldRenderAllLayers() {
+        GenerationConfig cfg = config(EnumSet.allOf(Layer.class));
+        List<GeneratedFile> files = renderer.renderAll(cfg);
+
+        assertThat(files).hasSize(Layer.values().length);
+    }
+}

--- a/springforge-engine/src/test/java/dev/springforge/engine/scanner/EntityScannerTest.java
+++ b/springforge-engine/src/test/java/dev/springforge/engine/scanner/EntityScannerTest.java
@@ -1,0 +1,77 @@
+package dev.springforge.engine.scanner;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EntityScannerTest {
+
+    private final EntityScanner scanner = new EntityScanner();
+
+    @Test
+    @DisplayName("should find all @Entity Java files in directory")
+    void shouldFindEntityFiles() throws IOException {
+        Path dir = Path.of("src/test/resources/entities");
+        List<Path> files = scanner.scanForEntityFiles(dir);
+
+        assertThat(files)
+            .hasSizeGreaterThanOrEqualTo(4)
+            .allMatch(p -> p.toString().endsWith(".java"));
+    }
+
+    @Test
+    @DisplayName("should not include files without @Entity annotation")
+    void shouldExcludeNonEntityFiles() throws IOException {
+        Path dir = Path.of("src/test/resources/entities");
+        List<Path> files = scanner.scanForEntityFiles(dir);
+
+        assertThat(files)
+            .noneMatch(p -> p.getFileName().toString().equals("PlainClass.java"))
+            .noneMatch(p -> p.getFileName().toString().equals("EmptyFile.java"));
+    }
+
+    @Test
+    @DisplayName("should return empty list when no entities found")
+    void shouldReturnEmptyWhenNoEntities(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("NotEntity.java"),
+            "public class NotEntity { }");
+
+        List<Path> files = scanner.scanForEntityFiles(tempDir);
+        assertThat(files).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return empty list when directory does not exist")
+    void shouldReturnEmptyWhenDirNotFound() throws IOException {
+        List<Path> files = scanner.scanForEntityFiles(Path.of("nonexistent/dir"));
+        assertThat(files).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should return empty list for non-directory path")
+    void shouldReturnEmptyForNonDirectory() throws IOException {
+        List<Path> files = scanner.scanForEntityFiles(
+            Path.of("src/test/resources/entities/User.java"));
+        assertThat(files).isEmpty();
+    }
+
+    @Test
+    @DisplayName("should scan nested directories")
+    void shouldScanNestedDirectories(@TempDir Path tempDir) throws IOException {
+        Path nested = tempDir.resolve("com/example/model");
+        Files.createDirectories(nested);
+        Files.writeString(nested.resolve("MyEntity.java"),
+            "import jakarta.persistence.Entity;\n@Entity\npublic class MyEntity {}");
+
+        List<Path> files = scanner.scanForEntityFiles(tempDir);
+        assertThat(files).hasSize(1);
+        assertThat(files.get(0).getFileName().toString()).isEqualTo("MyEntity.java");
+    }
+}

--- a/springforge-engine/src/test/java/dev/springforge/engine/writer/CodeFileWriterTest.java
+++ b/springforge-engine/src/test/java/dev/springforge/engine/writer/CodeFileWriterTest.java
@@ -1,0 +1,143 @@
+package dev.springforge.engine.writer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import dev.springforge.engine.model.ConflictStrategy;
+import dev.springforge.engine.model.FileGenerationResult;
+import dev.springforge.engine.model.GeneratedFile;
+import dev.springforge.engine.model.GenerationReport;
+import dev.springforge.engine.model.GenerationStatus;
+import dev.springforge.engine.model.Layer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CodeFileWriterTest {
+
+    private final CodeFileWriter writer = new CodeFileWriter();
+
+    @Nested
+    @DisplayName("File writing")
+    class FileWritingTest {
+
+        @Test
+        @DisplayName("should create file and parent directories")
+        void shouldCreateFileAndDirs(@TempDir Path tempDir) {
+            Path outputPath = tempDir.resolve("com/example/dto/UserRequestDto.java");
+            GeneratedFile file = new GeneratedFile(
+                outputPath, "package com.example.dto;", Layer.DTO_REQUEST, "User");
+
+            GenerationReport report = writer.writeAll(
+                List.of(file), ConflictStrategy.SKIP, tempDir);
+
+            assertThat(report.createdFiles()).isEqualTo(1);
+            assertThat(Files.exists(outputPath)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should write correct content to file")
+        void shouldWriteCorrectContent(@TempDir Path tempDir) throws IOException {
+            Path outputPath = tempDir.resolve("Test.java");
+            String content = "public class Test {}";
+            GeneratedFile file = new GeneratedFile(
+                outputPath, content, Layer.DTO_REQUEST, "Test");
+
+            writer.writeAll(List.of(file), ConflictStrategy.SKIP, tempDir);
+
+            assertThat(Files.readString(outputPath)).isEqualTo(content);
+        }
+
+        @Test
+        @DisplayName("should report correct counts in GenerationReport")
+        void shouldReportCorrectCounts(@TempDir Path tempDir) throws IOException {
+            Path existing = tempDir.resolve("Existing.java");
+            Files.writeString(existing, "old content");
+
+            List<GeneratedFile> files = List.of(
+                new GeneratedFile(
+                    tempDir.resolve("New.java"), "new", Layer.DTO_REQUEST, "New"),
+                new GeneratedFile(
+                    existing, "updated", Layer.DTO_RESPONSE, "Existing")
+            );
+
+            GenerationReport report = writer.writeAll(
+                files, ConflictStrategy.SKIP, tempDir);
+
+            assertThat(report.totalFiles()).isEqualTo(2);
+            assertThat(report.createdFiles()).isEqualTo(1);
+            assertThat(report.skippedFiles()).isEqualTo(1);
+            assertThat(report.errorFiles()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("Skip strategy")
+    class SkipStrategyTest {
+
+        @Test
+        @DisplayName("should skip existing files with SKIP strategy")
+        void shouldSkipExistingFiles(@TempDir Path tempDir) throws IOException {
+            Path existing = tempDir.resolve("Existing.java");
+            Files.writeString(existing, "original");
+
+            GeneratedFile file = new GeneratedFile(
+                existing, "replaced", Layer.DTO_REQUEST, "Existing");
+
+            GenerationReport report = writer.writeAll(
+                List.of(file), ConflictStrategy.SKIP, tempDir);
+
+            assertThat(report.skippedFiles()).isEqualTo(1);
+            assertThat(Files.readString(existing)).isEqualTo("original");
+        }
+    }
+
+    @Nested
+    @DisplayName("Overwrite strategy")
+    class OverwriteStrategyTest {
+
+        @Test
+        @DisplayName("should overwrite existing files with OVERWRITE strategy")
+        void shouldOverwriteExistingFiles(@TempDir Path tempDir) throws IOException {
+            Path existing = tempDir.resolve("Existing.java");
+            Files.writeString(existing, "original");
+
+            GeneratedFile file = new GeneratedFile(
+                existing, "replaced", Layer.DTO_REQUEST, "Existing");
+
+            GenerationReport report = writer.writeAll(
+                List.of(file), ConflictStrategy.OVERWRITE, tempDir);
+
+            assertThat(report.createdFiles()).isEqualTo(1);
+            assertThat(Files.readString(existing)).isEqualTo("replaced");
+        }
+    }
+
+    @Nested
+    @DisplayName("Path traversal rejection")
+    class PathTraversalTest {
+
+        @Test
+        @DisplayName("should reject ../ path traversal")
+        void shouldRejectPathTraversal(@TempDir Path tempDir) {
+            Path maliciousPath = tempDir.resolve("../../../etc/passwd");
+            GeneratedFile file = new GeneratedFile(
+                maliciousPath, "malicious", Layer.DTO_REQUEST, "Evil");
+
+            GenerationReport report = writer.writeAll(
+                List.of(file), ConflictStrategy.OVERWRITE, tempDir);
+
+            assertThat(report.errorFiles()).isEqualTo(1);
+
+            FileGenerationResult result = report.results().get(0);
+            assertThat(result.status()).isEqualTo(GenerationStatus.ERROR);
+            assertThat(result.message()).contains("Path traversal");
+        }
+    }
+}

--- a/springforge-engine/src/test/resources/entities/EmbeddedEntity.java
+++ b/springforge-engine/src/test/resources/entities/EmbeddedEntity.java
@@ -1,0 +1,17 @@
+package com.example.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Embedded;
+
+@Entity
+public class EmbeddedEntity {
+
+    @Id
+    private Long id;
+
+    @Embedded
+    private Address address;
+
+    private String name;
+}

--- a/springforge-engine/src/test/resources/entities/EmptyFile.java
+++ b/springforge-engine/src/test/resources/entities/EmptyFile.java
@@ -1,0 +1,1 @@
+package com.example.model;

--- a/springforge-engine/src/test/resources/entities/Order.java
+++ b/springforge-engine/src/test/resources/entities/Order.java
@@ -1,0 +1,22 @@
+package com.example.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Column;
+
+@Entity
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String orderNumber;
+
+    @ManyToOne
+    private User user;
+}

--- a/springforge-engine/src/test/resources/entities/PlainClass.java
+++ b/springforge-engine/src/test/resources/entities/PlainClass.java
@@ -1,0 +1,6 @@
+package com.example.model;
+
+public class PlainClass {
+    private Long id;
+    private String name;
+}

--- a/springforge-engine/src/test/resources/entities/Product.java
+++ b/springforge-engine/src/test/resources/entities/Product.java
@@ -1,0 +1,22 @@
+package com.example.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Column;
+import javax.persistence.ManyToOne;
+import java.math.BigDecimal;
+
+@Entity
+public class Product {
+
+    @Id
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private BigDecimal price;
+
+    @ManyToOne
+    private Category category;
+}

--- a/springforge-engine/src/test/resources/entities/User.java
+++ b/springforge-engine/src/test/resources/entities/User.java
@@ -1,0 +1,30 @@
+package com.example.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.OneToMany;
+import lombok.Data;
+import lombok.Builder;
+import java.util.List;
+
+@Entity
+@Data
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(unique = true)
+    private String email;
+
+    @OneToMany(mappedBy = "user")
+    private List<Order> orders;
+}

--- a/springforge-engine/src/test/resources/yaml/entities.yaml
+++ b/springforge-engine/src/test/resources/yaml/entities.yaml
@@ -1,0 +1,16 @@
+entities:
+  - name: Product
+    package: com.example.model
+    lombok: true
+    fields:
+      - name: id
+        type: Long
+        id: true
+      - name: name
+        type: String
+        nullable: false
+      - name: price
+        type: BigDecimal
+      - name: category
+        type: Category
+        relation: ManyToOne

--- a/springforge-engine/src/test/resources/yaml/invalid.yaml
+++ b/springforge-engine/src/test/resources/yaml/invalid.yaml
@@ -1,0 +1,2 @@
+something:
+  - wrong: true

--- a/springforge-templates/build.gradle
+++ b/springforge-templates/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java-library'
+}

--- a/springforge-templates/src/main/resources/templates/controller/Controller.java.mustache
+++ b/springforge-templates/src/main/resources/templates/controller/Controller.java.mustache
@@ -1,0 +1,58 @@
+package {{config.controllerPackage}};
+
+import {{config.dtoPackage}}.{{entity.name}}RequestDto;
+import {{config.dtoPackage}}.{{entity.name}}ResponseDto;
+import {{config.servicePackage}}.{{entity.name}}Service;
+import {{config.namespace}}.validation.Valid;
+{{#config.useLombok}}
+import lombok.RequiredArgsConstructor;
+{{/config.useLombok}}
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("{{config.apiPath}}")
+{{#config.useLombok}}
+@RequiredArgsConstructor
+{{/config.useLombok}}
+public class {{entity.name}}Controller {
+
+    private final {{entity.name}}Service {{entity.nameLower}}Service;
+{{^config.useLombok}}
+
+    public {{entity.name}}Controller({{entity.name}}Service {{entity.nameLower}}Service) {
+        this.{{entity.nameLower}}Service = {{entity.nameLower}}Service;
+    }
+{{/config.useLombok}}
+
+    @GetMapping
+    public ResponseEntity<Page<{{entity.name}}ResponseDto>> getAll(Pageable pageable) {
+        return ResponseEntity.ok({{entity.nameLower}}Service.findAll(pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<{{entity.name}}ResponseDto> getById(@PathVariable {{entity.idField.type}} id) {
+        return ResponseEntity.ok({{entity.nameLower}}Service.findById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<{{entity.name}}ResponseDto> create(
+            @Valid @RequestBody {{entity.name}}RequestDto dto) {
+        return ResponseEntity.status(201).body({{entity.nameLower}}Service.create(dto));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<{{entity.name}}ResponseDto> update(
+            @PathVariable {{entity.idField.type}} id,
+            @Valid @RequestBody {{entity.name}}RequestDto dto) {
+        return ResponseEntity.ok({{entity.nameLower}}Service.update(id, dto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable {{entity.idField.type}} id) {
+        {{entity.nameLower}}Service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/springforge-templates/src/main/resources/templates/controller/FileController.java.mustache
+++ b/springforge-templates/src/main/resources/templates/controller/FileController.java.mustache
@@ -1,0 +1,32 @@
+package {{config.controllerPackage}};
+
+{{#config.useLombok}}
+import lombok.RequiredArgsConstructor;
+{{/config.useLombok}}
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("{{config.apiPath}}")
+{{#config.useLombok}}
+@RequiredArgsConstructor
+{{/config.useLombok}}
+public class {{entity.name}}FileController {
+
+    private final {{entity.name}}Service {{entity.nameLower}}Service;
+{{^config.useLombok}}
+
+    public {{entity.name}}FileController({{entity.name}}Service {{entity.nameLower}}Service) {
+        this.{{entity.nameLower}}Service = {{entity.nameLower}}Service;
+    }
+{{/config.useLombok}}
+
+    @PostMapping("/{id}/upload")
+    public ResponseEntity<Void> uploadFile(
+            @PathVariable {{entity.idField.type}} id,
+            @RequestParam("file") MultipartFile file) {
+        // TODO: implement file upload logic
+        return ResponseEntity.ok().build();
+    }
+}

--- a/springforge-templates/src/main/resources/templates/dto/RequestDto.java.mustache
+++ b/springforge-templates/src/main/resources/templates/dto/RequestDto.java.mustache
@@ -1,0 +1,34 @@
+package {{config.dtoPackage}};
+
+{{#config.useLombok}}
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+{{/config.useLombok}}
+import {{config.namespace}}.validation.constraints.NotNull;
+
+{{#config.useLombok}}
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+{{/config.useLombok}}
+public class {{entity.name}}RequestDto {
+
+{{#entity.nonIdFields}}
+    private {{dtoType}} {{dtoFieldName}};
+{{/entity.nonIdFields}}
+{{^config.useLombok}}
+{{#entity.nonIdFields}}
+
+    public {{dtoType}} get{{nameCapitalized}}() {
+        return {{dtoFieldName}};
+    }
+
+    public void set{{nameCapitalized}}({{dtoType}} {{dtoFieldName}}) {
+        this.{{dtoFieldName}} = {{dtoFieldName}};
+    }
+{{/entity.nonIdFields}}
+{{/config.useLombok}}
+}

--- a/springforge-templates/src/main/resources/templates/dto/ResponseDto.java.mustache
+++ b/springforge-templates/src/main/resources/templates/dto/ResponseDto.java.mustache
@@ -1,0 +1,33 @@
+package {{config.dtoPackage}};
+
+{{#config.useLombok}}
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+{{/config.useLombok}}
+
+{{#config.useLombok}}
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+{{/config.useLombok}}
+public class {{entity.name}}ResponseDto {
+
+{{#entity.fields}}
+    private {{dtoType}} {{dtoFieldName}};
+{{/entity.fields}}
+{{^config.useLombok}}
+{{#entity.fields}}
+
+    public {{dtoType}} get{{nameCapitalized}}() {
+        return {{dtoFieldName}};
+    }
+
+    public void set{{nameCapitalized}}({{dtoType}} {{dtoFieldName}}) {
+        this.{{dtoFieldName}} = {{dtoFieldName}};
+    }
+{{/entity.fields}}
+{{/config.useLombok}}
+}

--- a/springforge-templates/src/main/resources/templates/mapper/MapstructMapper.java.mustache
+++ b/springforge-templates/src/main/resources/templates/mapper/MapstructMapper.java.mustache
@@ -1,0 +1,17 @@
+package {{config.mapperPackage}};
+
+import {{config.dtoPackage}}.{{entity.name}}RequestDto;
+import {{config.dtoPackage}}.{{entity.name}}ResponseDto;
+import {{entity.package}}.{{entity.name}};
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface {{entity.name}}Mapper {
+
+    {{entity.name}}ResponseDto toResponseDto({{entity.name}} entity);
+
+    {{entity.name}} toEntity({{entity.name}}RequestDto dto);
+
+    void updateEntityFromDto({{entity.name}}RequestDto dto, @MappingTarget {{entity.name}} entity);
+}

--- a/springforge-templates/src/main/resources/templates/mapper/ModelMapperConfig.java.mustache
+++ b/springforge-templates/src/main/resources/templates/mapper/ModelMapperConfig.java.mustache
@@ -1,0 +1,29 @@
+package {{config.mapperPackage}};
+
+import {{config.dtoPackage}}.{{entity.name}}RequestDto;
+import {{config.dtoPackage}}.{{entity.name}}ResponseDto;
+import {{entity.package}}.{{entity.name}};
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class {{entity.name}}Mapper {
+
+    private final ModelMapper modelMapper;
+
+    public {{entity.name}}Mapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    public {{entity.name}}ResponseDto toResponseDto({{entity.name}} entity) {
+        return modelMapper.map(entity, {{entity.name}}ResponseDto.class);
+    }
+
+    public {{entity.name}} toEntity({{entity.name}}RequestDto dto) {
+        return modelMapper.map(dto, {{entity.name}}.class);
+    }
+
+    public void updateEntityFromDto({{entity.name}}RequestDto dto, {{entity.name}} entity) {
+        modelMapper.map(dto, entity);
+    }
+}

--- a/springforge-templates/src/main/resources/templates/repository/Repository.java.mustache
+++ b/springforge-templates/src/main/resources/templates/repository/Repository.java.mustache
@@ -1,0 +1,9 @@
+package {{config.repositoryPackage}};
+
+import {{entity.package}}.{{entity.name}};
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface {{entity.name}}Repository extends JpaRepository<{{entity.name}}, {{entity.idField.type}}> {
+}

--- a/springforge-templates/src/main/resources/templates/service/Service.java.mustache
+++ b/springforge-templates/src/main/resources/templates/service/Service.java.mustache
@@ -1,0 +1,19 @@
+package {{config.servicePackage}};
+
+import {{config.dtoPackage}}.{{entity.name}}RequestDto;
+import {{config.dtoPackage}}.{{entity.name}}ResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface {{entity.name}}Service {
+
+    Page<{{entity.name}}ResponseDto> findAll(Pageable pageable);
+
+    {{entity.name}}ResponseDto findById({{entity.idField.type}} id);
+
+    {{entity.name}}ResponseDto create({{entity.name}}RequestDto dto);
+
+    {{entity.name}}ResponseDto update({{entity.idField.type}} id, {{entity.name}}RequestDto dto);
+
+    void delete({{entity.idField.type}} id);
+}

--- a/springforge-templates/src/main/resources/templates/service/ServiceImpl.java.mustache
+++ b/springforge-templates/src/main/resources/templates/service/ServiceImpl.java.mustache
@@ -1,0 +1,73 @@
+package {{config.servicePackage}}.impl;
+
+import {{config.dtoPackage}}.{{entity.name}}RequestDto;
+import {{config.dtoPackage}}.{{entity.name}}ResponseDto;
+import {{config.mapperPackage}}.{{entity.name}}Mapper;
+import {{config.repositoryPackage}}.{{entity.name}}Repository;
+import {{config.servicePackage}}.{{entity.name}}Service;
+import {{entity.package}}.{{entity.name}};
+{{#config.useLombok}}
+import lombok.RequiredArgsConstructor;
+{{/config.useLombok}}
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+{{#config.useLombok}}
+@RequiredArgsConstructor
+{{/config.useLombok}}
+public class {{entity.name}}ServiceImpl implements {{entity.name}}Service {
+
+    private final {{entity.name}}Repository {{entity.nameLower}}Repository;
+    private final {{entity.name}}Mapper {{entity.nameLower}}Mapper;
+{{^config.useLombok}}
+
+    public {{entity.name}}ServiceImpl({{entity.name}}Repository {{entity.nameLower}}Repository,
+                              {{entity.name}}Mapper {{entity.nameLower}}Mapper) {
+        this.{{entity.nameLower}}Repository = {{entity.nameLower}}Repository;
+        this.{{entity.nameLower}}Mapper = {{entity.nameLower}}Mapper;
+    }
+{{/config.useLombok}}
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<{{entity.name}}ResponseDto> findAll(Pageable pageable) {
+        return {{entity.nameLower}}Repository.findAll(pageable)
+                .map({{entity.nameLower}}Mapper::toResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public {{entity.name}}ResponseDto findById({{entity.idField.type}} id) {
+        {{entity.name}} entity = {{entity.nameLower}}Repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("{{entity.name}} not found with id: " + id));
+        return {{entity.nameLower}}Mapper.toResponseDto(entity);
+    }
+
+    @Override
+    public {{entity.name}}ResponseDto create({{entity.name}}RequestDto dto) {
+        {{entity.name}} entity = {{entity.nameLower}}Mapper.toEntity(dto);
+        {{entity.name}} saved = {{entity.nameLower}}Repository.save(entity);
+        return {{entity.nameLower}}Mapper.toResponseDto(saved);
+    }
+
+    @Override
+    public {{entity.name}}ResponseDto update({{entity.idField.type}} id, {{entity.name}}RequestDto dto) {
+        {{entity.name}} entity = {{entity.nameLower}}Repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("{{entity.name}} not found with id: " + id));
+        {{entity.nameLower}}Mapper.updateEntityFromDto(dto, entity);
+        {{entity.name}} saved = {{entity.nameLower}}Repository.save(entity);
+        return {{entity.nameLower}}Mapper.toResponseDto(saved);
+    }
+
+    @Override
+    public void delete({{entity.idField.type}} id) {
+        if (!{{entity.nameLower}}Repository.existsById(id)) {
+            throw new RuntimeException("{{entity.name}} not found with id: " + id);
+        }
+        {{entity.nameLower}}Repository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary

- **EntityScanner** (#2): scans `src/` for `@Entity` files with fast string pre-filter, returns empty list on missing dirs
- **JavaAstEntityParser** (#3): parses `@Entity` via AST — extracts fields, types, JPA annotations, detects Lombok, javax/jakarta namespace, circular references (ID-flattening), skips `@Embedded` with warning
- **YamlEntityParser** (#4): parses YAML entity definitions into the same `EntityDescriptor` model
- **TemplateRenderer** (#5): Mustache-based code generation with `TemplateContextBuilder`, `OutputPathResolver`, user template override support
- **CodeFileWriter** (#6): writes files with skip/overwrite conflict strategies, rejects `../` path traversal, auto-creates directories
- **DTO layer** (#7): `RequestDto` (excludes @Id), `ResponseDto` (all fields), circular ref → ID flattening
- **Repository/Service/Controller layers** (#8): JpaRepository, Service interface, ServiceImpl with constructor injection, Controller with full CRUD + file upload endpoint
- **46 unit tests** (#9): covers all components with happy paths + error cases

Closes #2, Closes #3, Closes #4, Closes #5, Closes #6, Closes #7, Closes #8, Closes #9

## Modules Added

| Module | Purpose |
|---|---|
| `springforge-engine` | Scanner, parsers, renderer, writer, data models |
| `springforge-templates` | 9 Mustache templates (DTO, Mapper, Repo, Service, Controller) |

## Test plan

- [x] 46 engine tests pass (EntityScanner, JavaAstEntityParser, YamlEntityParser, TemplateRenderer, CodeFileWriter)
- [x] 13 CLI tests still pass (59 total)
- [x] Full `./gradlew build` succeeds
- [x] CI pipeline validates on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)