### PR TITLE
fix(ci): remove push trigger on develop to avoid duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
     branches: [ main, develop ]
 


### PR DESCRIPTION
## Summary
- Remove `push` trigger on `develop` branch — merging a PR fires both `push` and `pull_request` events, causing two identical CI runs
- Keep `push` on `main` only (final validation after release merge)
- `pull_request` on both `main` and `develop` remains (PR gate)

## Test plan
- [x] Verify only `pull_request` event fires for this PR (no duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)