### PR TITLE
chore(cli): synchronize app version from Gradle manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
     apply plugin: 'checkstyle'
 
     group = 'dev.springforge'
-    version = '0.1.0-SNAPSHOT'
+    version = '1.0.0-SNAPSHOT'
 
     java {
         sourceCompatibility = JavaVersion.VERSION_21
@@ -37,6 +37,15 @@ subprojects {
 
     tasks.withType(JavaCompile).configureEach {
         options.encoding = 'UTF-8'
+    }
+
+    tasks.withType(Jar).configureEach {
+        manifest {
+            attributes(
+                'Implementation-Title': project.name,
+                'Implementation-Version': project.version
+            )
+        }
     }
 
     tasks.withType(Test).configureEach {

--- a/springforge-cli/src/main/java/dev/springforge/cli/MainCommand.java
+++ b/springforge-cli/src/main/java/dev/springforge/cli/MainCommand.java
@@ -12,7 +12,7 @@ import picocli.CommandLine.Option;
     name = "springforge",
     description = "SpringForge — Generate Spring Boot API layers from @Entity classes",
     mixinStandardHelpOptions = true,
-    version = "1.0.0-SNAPSHOT",
+    versionProvider = ManifestVersionProvider.class,
     subcommands = {
         GenerateCommand.class,
         InitCommand.class,

--- a/springforge-cli/src/main/java/dev/springforge/cli/ManifestVersionProvider.java
+++ b/springforge-cli/src/main/java/dev/springforge/cli/ManifestVersionProvider.java
@@ -1,0 +1,22 @@
+package dev.springforge.cli;
+
+import picocli.CommandLine.IVersionProvider;
+
+/**
+ * Reads the application version from the JAR manifest
+ * ({@code Implementation-Version}), injected by Gradle at build time.
+ * Falls back to "dev" when running from an IDE or unpackaged classpath.
+ */
+public final class ManifestVersionProvider implements IVersionProvider {
+
+    private static final String FALLBACK_VERSION = "dev";
+
+    @Override
+    public String[] getVersion() {
+        String version = MainCommand.class.getPackage()
+            .getImplementationVersion();
+        return new String[]{
+            "springforge " + (version != null ? version : FALLBACK_VERSION)
+        };
+    }
+}

--- a/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/reflect-config.json
+++ b/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/reflect-config.json
@@ -6,6 +6,11 @@
     "allDeclaredFields": true
   },
   {
+    "name": "dev.springforge.cli.ManifestVersionProvider",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
     "name": "dev.springforge.cli.GenerateCommand",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,


### PR DESCRIPTION
## Summary
- Replace hardcoded `version = "1.0.0-SNAPSHOT"` in `MainCommand` with `ManifestVersionProvider` (Picocli `IVersionProvider`)
- Version is read from JAR manifest `Implementation-Version` at runtime, falls back to `dev` in IDE
- Add `Implementation-Title` and `Implementation-Version` to all subproject JAR manifests via root `build.gradle`
- Bump project version from `0.1.0-SNAPSHOT` to `1.0.0-SNAPSHOT`
- Add `ManifestVersionProvider` to GraalVM `reflect-config.json`

**Flow:** `git tag v1.0.0` → workflow `-Pversion=1.0.0` → `springforge --version` → `springforge 1.0.0`

## Test plan
- [x] `./gradlew test checkstyleMain checkstyleTest spotbugsMain` — all pass
- [x] `java -jar springforge-cli-1.0.0-SNAPSHOT-all.jar --version` → `springforge 1.0.0-SNAPSHOT`
- [x] CI validates compile → test → quality → native-image

🤖 Generated with [Claude Code](https://claude.com/claude-code)