### PR TITLE
Read app version from JAR manifest and update to 1.0.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
     apply plugin: 'checkstyle'
 
     group = 'dev.springforge'
-    version = '0.1.0-SNAPSHOT'
+    version = '1.0.0-SNAPSHOT'
 
     java {
         sourceCompatibility = JavaVersion.VERSION_21
@@ -37,6 +37,15 @@ subprojects {
 
     tasks.withType(JavaCompile).configureEach {
         options.encoding = 'UTF-8'
+    }
+
+    tasks.withType(Jar).configureEach {
+        manifest {
+            attributes(
+                'Implementation-Title': project.name,
+                'Implementation-Version': project.version
+            )
+        }
     }
 
     tasks.withType(Test).configureEach {

--- a/springforge-cli/src/main/java/dev/springforge/cli/MainCommand.java
+++ b/springforge-cli/src/main/java/dev/springforge/cli/MainCommand.java
@@ -12,7 +12,7 @@ import picocli.CommandLine.Option;
     name = "springforge",
     description = "SpringForge — Generate Spring Boot API layers from @Entity classes",
     mixinStandardHelpOptions = true,
-    version = "1.0.0-SNAPSHOT",
+    versionProvider = ManifestVersionProvider.class,
     subcommands = {
         GenerateCommand.class,
         InitCommand.class,

--- a/springforge-cli/src/main/java/dev/springforge/cli/ManifestVersionProvider.java
+++ b/springforge-cli/src/main/java/dev/springforge/cli/ManifestVersionProvider.java
@@ -1,0 +1,22 @@
+package dev.springforge.cli;
+
+import picocli.CommandLine.IVersionProvider;
+
+/**
+ * Reads the application version from the JAR manifest
+ * ({@code Implementation-Version}), injected by Gradle at build time.
+ * Falls back to "dev" when running from an IDE or unpackaged classpath.
+ */
+public final class ManifestVersionProvider implements IVersionProvider {
+
+    private static final String FALLBACK_VERSION = "dev";
+
+    @Override
+    public String[] getVersion() {
+        String version = MainCommand.class.getPackage()
+            .getImplementationVersion();
+        return new String[]{
+            "springforge " + (version != null ? version : FALLBACK_VERSION)
+        };
+    }
+}

--- a/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/reflect-config.json
+++ b/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/reflect-config.json
@@ -6,6 +6,11 @@
     "allDeclaredFields": true
   },
   {
+    "name": "dev.springforge.cli.ManifestVersionProvider",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
     "name": "dev.springforge.cli.GenerateCommand",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,


### PR DESCRIPTION
This pull request improves how the CLI displays its version information by introducing a new `ManifestVersionProvider` and updating related configuration. The most important changes are:

**Version Handling Improvements:**

* Added a new `ManifestVersionProvider` class that reads the application version from the JAR manifest (`Implementation-Version`), with a fallback to "dev" when running from an IDE or unpackaged classpath. (`springforge-cli/src/main/java/dev/springforge/cli/ManifestVersionProvider.java`)
* Updated the `@Command` annotation in `MainCommand.java` to use `versionProvider = ManifestVersionProvider.class` instead of a hardcoded version string. (`springforge-cli/src/main/java/dev/springforge/cli/MainCommand.java`)

**Native Image Configuration:**

* Added reflection configuration for `ManifestVersionProvider` to the GraalVM native image `reflect-config.json`, ensuring it works correctly when compiled to a native executable. (`springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/reflect-config.json`)