### PR TITLE
Enhance CLI versioning, add uninstall script, and improve native support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and publish to GitHub Packages
-        run: ./gradlew :springforge-cli:fatJar :springforge-cli:publish -Pversion=${{ steps.version.outputs.version }}
+        run: ./gradlew :springforge-cli:fatJar :springforge-cli:publish -PreleaseVersion=${{ steps.version.outputs.version }}
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build native image
-        run: ./gradlew :springforge-cli:nativeCompile
+        run: ./gradlew :springforge-cli:nativeCompile -PreleaseVersion=${GITHUB_REF_NAME#v}
 
       - name: Rename binary
         run: mv springforge-cli/build/native/nativeCompile/springforge springforge-cli/build/native/nativeCompile/${{ matrix.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,3 +85,4 @@ jobs:
             release-assets/springforge-linux-x86_64
             release-assets/springforge-macos-aarch64
             install.sh
+            uninstall.sh

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Or use the install script:
 curl -L https://github.com/CedricNdong/springforge-tui/releases/latest/download/install.sh | bash
 ```
 
+### Uninstall
+
+```bash
+curl -L https://github.com/CedricNdong/springforge-tui/releases/latest/download/uninstall.sh | bash
+```
+
 ### Option 2 — Fat JAR (requires Java 21+)
 
 Download `springforge-tui-*-all.jar` from the [releases page](https://github.com/CedricNdong/springforge-tui/releases) and run:

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ subprojects {
     apply plugin: 'checkstyle'
 
     group = 'dev.springforge'
-    version = '1.0.0-SNAPSHOT'
+    version = findProperty('releaseVersion') ?: '0.0.0-dev'
 
     java {
         sourceCompatibility = JavaVersion.VERSION_21

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,25 @@ main() {
     fi
 
     echo ""
-    echo "SpringForge ${version} installed to ${INSTALL_DIR}/${BINARY_NAME}"
+
+    # Post-install verification
+    local expected_version="${version#v}"
+    local actual_version
+    if ! actual_version=$("${INSTALL_DIR}/${BINARY_NAME}" --version 2>&1); then
+        echo "Warning: Binary installed but failed to execute." >&2
+        echo "This may indicate a missing library or incompatible platform." >&2
+        echo "Try running: ${INSTALL_DIR}/${BINARY_NAME} --version" >&2
+        exit 1
+    fi
+
+    if echo "$actual_version" | grep -q "$expected_version"; then
+        echo "SpringForge ${version} installed to ${INSTALL_DIR}/${BINARY_NAME}"
+        echo "Verified: ${actual_version}"
+    else
+        echo "SpringForge installed to ${INSTALL_DIR}/${BINARY_NAME}"
+        echo "Warning: Version mismatch — expected ${expected_version}, got: ${actual_version}" >&2
+    fi
+
     echo "Run 'springforge --help' to get started."
 }
 

--- a/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/reflect-config.json
+++ b/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/reflect-config.json
@@ -303,6 +303,32 @@
   },
 
   {
+    "name": "dev.tamboui.backend.jline3.JLineBackendProvider",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "dev.tamboui.backend.jline3.JLineBackend",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "dev.tamboui.capability.core.CoreCapabilityProvider",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "dev.tamboui.terminal.BackendProvider",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "dev.tamboui.capability.CapabilityProvider",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true
+  },
+
+  {
     "name": "org.slf4j.simple.SimpleServiceProvider",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true

--- a/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/resource-config.json
+++ b/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/resource-config.json
@@ -8,7 +8,16 @@
         "pattern": ".*\\.java$"
       },
       {
-        "pattern": "dev/tamboui/tui/bindings/.*\\.properties$"
+        "pattern": "dev/tamboui/.*\\.properties$"
+      },
+      {
+        "pattern": "META-INF/services/dev\\.tamboui\\..*"
+      },
+      {
+        "pattern": "org/jline/utils/.*\\.caps$"
+      },
+      {
+        "pattern": "org/jline/nativ/.*"
       },
       {
         "pattern": "com/github/javaparser/.*\\.properties$"

--- a/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/resource-config.json
+++ b/springforge-cli/src/main/resources/META-INF/native-image/dev.springforge/springforge-cli/resource-config.json
@@ -8,7 +8,7 @@
         "pattern": ".*\\.java$"
       },
       {
-        "pattern": "templates/.*\\.mustache$"
+        "pattern": "dev/tamboui/tui/bindings/.*\\.properties$"
       },
       {
         "pattern": "com/github/javaparser/.*\\.properties$"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# SpringForge TUI uninstaller
+# Usage: curl -L https://github.com/CedricNdong/springforge-tui/releases/latest/download/uninstall.sh | bash
+#
+set -euo pipefail
+
+INSTALL_DIR="${SPRINGFORGE_INSTALL_DIR:-/usr/local/bin}"
+BINARY_NAME="springforge"
+BINARY_PATH="${INSTALL_DIR}/${BINARY_NAME}"
+
+main() {
+    echo "SpringForge TUI Uninstaller"
+    echo "==========================="
+    echo ""
+
+    if [ ! -f "$BINARY_PATH" ]; then
+        echo "SpringForge is not installed at ${BINARY_PATH}."
+        echo "Nothing to remove."
+        exit 0
+    fi
+
+    local version
+    version=$("$BINARY_PATH" --version 2>/dev/null || echo "unknown version")
+    echo "Found: ${version} at ${BINARY_PATH}"
+
+    if [ -w "$INSTALL_DIR" ]; then
+        rm -f "$BINARY_PATH"
+    else
+        echo "Removing from ${INSTALL_DIR} requires sudo..."
+        sudo rm -f "$BINARY_PATH"
+    fi
+
+    echo "SpringForge has been uninstalled."
+}
+
+main


### PR DESCRIPTION
This pull request introduces improvements to the installation and release process for SpringForge, including a new uninstall script, enhancements to install verification, and updates to native-image build and resource configuration. The most important changes are as follows:

**Install/Uninstall Scripts:**

* Added a new `uninstall.sh` script for easy removal of SpringForge and documented its usage in the `README.md`. [[1]](diffhunk://#diff-794e65e0ee6053d90c158cf942f93caee8a9fb1473830f1ccd660cf865c90828R1-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R142)
* Enhanced `install.sh` with post-install verification to check that the installed binary matches the expected version and provides clear warnings if there are issues.

**Release Workflow Improvements:**

* Updated `.github/workflows/release.yml` to include `uninstall.sh` as a release asset and to pass the release version to the native image build step for consistency. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L43-R43) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R88)
* Changed the publish workflow in `.github/workflows/publish.yml` to pass the release version as `-PreleaseVersion` instead of `-Pversion` for better alignment with build tooling.

**Native Image Configuration:**

* Updated `reflect-config.json` and `resource-config.json` to add necessary classes and resource patterns for GraalVM native-image compatibility with new dependencies (e.g., JLine3, Tamboui backend). [[1]](diffhunk://#diff-4a2ecd78c7d5d386ca100b1483a969e170a23a77467a0a98bdde9acba79af729R305-R330) [[2]](diffhunk://#diff-0d4f41a580b016e33162d21cd5a613a1f702915c8615298585ccd4d3f3e49b3dL11-R20)